### PR TITLE
Don't create directory entries by default.

### DIFF
--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
@@ -83,8 +83,10 @@ class RpmCopySpecVisitor extends EmptyCopySpecVisitor {
 
     @Override
     void visitDir(FileVisitDetails dirDetails) {
-        logger.debug "adding directory {}", dirDetails.relativePath.pathString
-        builder.addDirectory "/" + dirDetails.relativePath.pathString, spec.dirMode, spec.directive, spec.user ?: task.user, spec.group ?: task.group
+        if (spec.createDirectoryEntry) {
+            logger.debug "adding directory {}", dirDetails.relativePath.pathString
+            builder.addDirectory "/" + dirDetails.relativePath.pathString, spec.dirMode, spec.directive, spec.user ?: task.user, spec.group ?: task.group
+        }
     }
 
     @Override

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmPlugin.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmPlugin.groovy
@@ -31,6 +31,7 @@ class RpmPlugin implements Plugin<Project> {
         CopySpecImpl.metaClass.user = null
         CopySpecImpl.metaClass.group = null
         CopySpecImpl.metaClass.directive = null
+        CopySpecImpl.metaClass.createDirectoryEntry = null
 
         Field.metaClass.hasModifier = { modifier ->
             (modifiers & modifier) == modifier 

--- a/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -59,6 +59,10 @@ class RpmPluginTest {
 
             into '/opt/bleah'
             from(srcDir)
+
+            from(srcDir.toString() + '/main/groovy') {
+                createDirectoryEntry = true
+            }
             
             link('/opt/bleah/banana', '/opt/bleah/apple')
         })


### PR DESCRIPTION
Because redline-rpm Builder automatically creates parent directories when needed, and, more importantly, skips creating directory entries for system directories (e.g. /etc), directory entries shouldn't be created by default.

A new copyspec property createDirectoryEntry is added to allow specifying that a directory entry should be created enableing specifying directory mode and/or ownership.
