### PR TITLE
Add convinence method for not specifying the version when adding an RPM requires directive

### DIFF
--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
@@ -136,6 +136,10 @@ class Rpm extends AbstractArchiveTask {
         dep
     }
     
+    Dependency requires(String packageName) {
+        requires(packageName, '', 0)
+    }
+
     class RpmCopyAction extends CopyActionImpl {
         public RpmCopyAction(FileResolver resolver) {
             super(resolver, new RpmCopySpecVisitor());

--- a/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -56,6 +56,7 @@ class RpmPluginTest {
             url = 'http://www.example.com/'
             
             requires('blarg', '1.0', GREATER | EQUAL)
+            requires('blech')
 
             into '/opt/bleah'
             from(srcDir)


### PR DESCRIPTION
Add convinence method for not specifying the version when adding an RPM requires directive.
