### PR TITLE
InetAddress.localHost can throw an exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 bin
 build
 gradle.properties
+
+out
+*.ipr
+*.iml
+*.iws

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'groovy'
 apply plugin: 'eclipse'
 apply plugin: 'nexus'
+apply plugin: 'idea'
 
 group = 'com.trigonic'
 version = '1.2-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     groovy 'org.codehaus.groovy:groovy:1.8.+'
 
     testCompile 'junit:junit:4.+'
+    testCompile([group: 'org.gmock', name: 'gmock', version: '0.8.2', transitive: false])
 }
 
 task packageJavadoc(type: Jar, dependsOn: 'javadoc') {

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
@@ -16,7 +16,6 @@
 
 package com.trigonic.gradle.plugins.rpm
 
-import java.io.File
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
@@ -38,8 +38,10 @@ class Rpm extends AbstractArchiveTask {
     String user
     String group
     String packageGroup = ''
-    String buildHost = InetAddress.localHost.hostName
+    String buildHost = getLocalHostName()
+
     String summary = ''
+
     String description = ''
     String license = ''
     String packager = System.getProperty('user.name', '')
@@ -86,6 +88,14 @@ class Rpm extends AbstractArchiveTask {
                 assert !ext.hasProperty(field.name)
                 ext.set field.name, field.get(null)
             }
+        }
+    }
+
+    private static String getLocalHostName() {
+        try {
+            return InetAddress.localHost.hostName
+        } catch (UnknownHostException ignore) {
+            return "unknown"
         }
     }
 


### PR DESCRIPTION
We've just started using this gradle plugin, and it's working great, but we've discovered one issue.

In some cases, the call to `InetAddress.localHost` (on line 41 of Rpm.gradle) can throw an UnknownHostException. When this happens the plugin crashes.

This pull request is a potential fix that catches the exception and uses a sensible default (the string 'unknown'). A unit test is also included.

(The pull request also includes the work I needed to do to get the gradle script to work with IntelliJ, and some _very_ minor code cleanup. Neither of those commits is relevant to the bug per se.)
