### PR TITLE
Optionally add parent directories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile 'org.redline-rpm:redline:1.1.+'
+    compile 'org.redline-rpm:redline:1.1.10+'
 
     groovy 'org.codehaus.groovy:groovy:1.8.+'
 

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
@@ -79,7 +79,8 @@ class RpmCopySpecVisitor extends EmptyCopySpecVisitor {
     void visitFile(FileVisitDetails fileDetails) {
         logger.debug "adding file {}", fileDetails.relativePath.pathString
         builder.addFile "/" + fileDetails.relativePath.pathString, fileDetails.file,
-            spec.fileMode == null ? -1 : spec.fileMode, spec.fileType, spec.user ?: task.user, spec.group ?: task.group
+            spec.fileMode == null ? -1 : spec.fileMode, -1, spec.fileType, spec.user ?: task.user, spec.group ?: task.group,
+                spec.addParentDirs
     }
 
     @Override
@@ -87,7 +88,7 @@ class RpmCopySpecVisitor extends EmptyCopySpecVisitor {
         if (spec.createDirectoryEntry) {
             logger.debug "adding directory {}", dirDetails.relativePath.pathString
             builder.addDirectory "/" + dirDetails.relativePath.pathString, spec.dirMode == null ? -1 : spec.dirMode,
-                spec.fileType, spec.user ?: task.user, spec.group ?: task.group
+                spec.fileType, spec.user ?: task.user, spec.group ?: task.group, spec.addParentDirs
         }
     }
 

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmPlugin.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmPlugin.groovy
@@ -34,6 +34,7 @@ class RpmPlugin implements Plugin<Project> {
         CopySpecImpl.metaClass.group = null
         CopySpecImpl.metaClass.fileType = null
         CopySpecImpl.metaClass.createDirectoryEntry = null
+        CopySpecImpl.metaClass.addParentDirs = true
 
         Field.metaClass.hasModifier = { modifier ->
             (modifiers & modifier) == modifier 

--- a/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
+++ b/src/test/groovy/com/trigonic/gradle/plugins/rpm/RpmPluginTest.groovy
@@ -39,6 +39,10 @@ class RpmPluginTest {
         srcDir.mkdirs()
         FileUtils.writeStringToFile(new File(srcDir, 'apple'), 'apple')
 
+        File noParentsDir = new File(buildDir, 'noParentsDir')
+        noParentsDir.mkdirs()
+        FileUtils.writeStringToFile(new File(noParentsDir, 'alone'), 'alone')
+
         project.apply plugin: 'rpm'
 
         project.task([type: Rpm], 'buildRpm', {
@@ -70,6 +74,11 @@ class RpmPluginTest {
                 fileType = CONFIG
             }
             
+            from(noParentsDir) {
+                addParentDirs = false
+                into '/a/path/not/to/create'
+            }
+
             link('/opt/bleah/banana', '/opt/bleah/apple')
         })
 
@@ -80,8 +89,9 @@ class RpmPluginTest {
         assertEquals('1', getHeaderEntryString(scan, RELEASE))
         assertEquals('i386', getHeaderEntryString(scan, ARCH))
         assertEquals('linux', getHeaderEntryString(scan, OS))
-        assertEquals(['./opt/bleah', './opt/bleah/apple', './opt/bleah/banana'], scan.files*.name)
-        assertEquals([DIR, FILE, SYMLINK], scan.files*.type)
+        assertEquals(['./a/path/not/to/create/alone', './opt/bleah',
+                      './opt/bleah/apple', './opt/bleah/banana'], scan.files*.name)
+        assertEquals([FILE, DIR, FILE, SYMLINK], scan.files*.type)
     }
 
     @Test


### PR DESCRIPTION
Do not add parent directories by default by using new option in redline-rpm to leave them out when adding files

Depends upon version 1.1.10 of redline-rpm

Provides addParentDirs boolean property that defaults to true to keep old behavior of always creating parent directories.
