### PR TITLE
Adding ability to add obsolete and conflict dependencies

### DIFF
--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/Rpm.groovy
@@ -59,6 +59,8 @@ class Rpm extends AbstractArchiveTask {
     File postUninstall
     List<Link> links = new ArrayList<Link>()
     List<Dependency> dependencies = new ArrayList<Dependency>();
+    List<Dependency> obsoletes = new ArrayList<Dependency>();
+    List<Dependency> conflicts = new ArrayList<Dependency>();
 
     Rpm() {
         action = new RpmCopyAction(services.get(Instantiator.class), services.get(FileResolver.class))
@@ -139,16 +141,41 @@ class Rpm extends AbstractArchiveTask {
     }
 
     Dependency requires(String packageName, String version, int flag) {
-        Dependency dep = new Dependency()
-        dep.packageName = packageName
-        dep.version = version
-        dep.flag = flag
+        Dependency dep = createDependency(packageName, version, flag)
         dependencies.add(dep)
         dep
     }
 
     Dependency requires(String packageName) {
         requires(packageName, '', 0)
+    }
+
+    Dependency obsolete(String packageName, String version, int flag) {
+        Dependency obs = createDependency(packageName, version, flag)
+        obsoletes.add(obs)
+        obs
+    }
+
+    Dependency obsolete(String packageName) {
+        obsolete(packageName, '', 0)
+    }
+
+    Dependency conflict(String packageName, String version, int flag) {
+        Dependency conf = createDependency(packageName, version, flag)
+        conflicts.add(conf)
+        conf
+    }
+
+    Dependency conflict(String packageName) {
+        conflict(packageName, '', 0)
+    }
+
+    private Dependency createDependency(String packageName, String version, int flag) {
+        Dependency dep = new Dependency()
+        dep.packageName = packageName
+        dep.version = version
+        dep.flag = flag
+        dep
     }
 
     class RpmCopyAction extends CopyActionImpl {

--- a/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
+++ b/src/main/groovy/com/trigonic/gradle/plugins/rpm/RpmCopySpecVisitor.groovy
@@ -105,6 +105,16 @@ class RpmCopySpecVisitor extends EmptyCopySpecVisitor {
             builder.addDependency dep.packageName, dep.version, dep.flag
         }
 
+        for (Dependency dep : task.obsoletes) {
+            logger.debug "adding obsolete on {} {}", dep.packageName, dep.version
+            builder.addObsoletes dep.packageName, dep.version, dep.flag
+        }
+
+        for (Dependency dep : task.conflicts) {
+            logger.debug "adding conflict on {} {}", dep.packageName, dep.version
+            builder.addConflicts dep.packageName, dep.version, dep.flag
+        }
+
         String rpmFile = builder.build(destinationDir)
         didWork = true
         logger.info 'Created rpm {}', rpmFile


### PR DESCRIPTION
Extended API to add functionality to add OBSOLETES and CONFLICTS headers fields in the RPM header. 
